### PR TITLE
Mutli-file patch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "non-melpa-elisp/header2"]
+	path = non-melpa-elisp/header2
+	url = git@github.com:emacsmirror/header2.git

--- a/elisp/init-ace-window.el
+++ b/elisp/init-ace-window.el
@@ -1,0 +1,54 @@
+;;; init-ace-window.el --- -*- lexical-binding: t -*-
+;;
+;; Filename: init-ace-window.el
+;; Description:
+;; Author: Ankur Saini
+;; Maintainer: Initialize Ace window
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Sun Jun 19 18:26:00 2022 (+0530)
+;; Version: 1.0
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 12
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: ace-window .emacs.d
+;; Compatibility: emacs-version >= 26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This file initialize ace-window package, which is a GNU Emacs
+;; package for selecting a window to switch to
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+(use-package ace-window
+  :bind ("C-x C-o" . ace-window))
+
+(provide 'init-ace-window)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-ace-window.el ends here

--- a/elisp/init-avy.el
+++ b/elisp/init-avy.el
@@ -1,0 +1,60 @@
+;;; init-avy.el --- -*- lexical-binding: t -*-
+;;
+;; Filename: init-avy.el
+;; Description: Initialise Avy
+;; Author: Ankur Saini
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Sun Jun 19 18:07:33 2022 (+0530)
+;; Version: 1.0
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 14
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: .emacs.d avy
+;; Compatibility: emacs-version >= 26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This file Initialize Avy, which is used for jumping to visible text
+;; using a char-based decision tree like ace-jump mode
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+(eval-when-compile
+  (require 'init-global-config))
+
+;;;;;;;;;;;;;;;;
+;; Avy config ;;
+;;;;;;;;;;;;;;;;
+
+(use-package avy
+  :bind ("M-s" . avy-goto-char-timer))
+
+(provide 'init-avy)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-avy.el ends here

--- a/elisp/init-cc.el
+++ b/elisp/init-cc.el
@@ -1,0 +1,91 @@
+;;; init-cc.el --- -*-lexical-binding: t-*-
+;;
+;; Filename: init-cc.el
+;; Description: Initialise c/c++ configuration
+;; Author: Ankur Saini
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Mon Jun 20 13:05:07 2022 (+0530)
+;; Version: 1.0
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 7
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: c c++ cc .emacs.d
+;; Compatibility: emacs-version >= 26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This file initialise every package dealing with C and C++
+;; specifically
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+
+;; clang format to properly format code
+;; TODO: posibliy replace it with format all
+(use-package clang-format
+  :init (setq clang-format-style "GNU")
+  :bind ("C-c f" . clang-format-buffer))
+
+;; follow gnu coding convention by defult
+(setq c-default-style "gnu")
+
+;; font-locking for "Modern C++"
+(use-package modern-cpp-font-lock
+  :diminish t
+  :init (modern-c++-font-lock-global-mode t))
+
+;; ggtags (gnu global tags) to jump to symbol definitions
+(use-package ggtags
+  :init
+  (add-hook 'c-mode-common-hook
+            (lambda ()
+              (when (derived-mode-p 'c-mode 'c++-mode 'java-mode 'asm-mode)
+                (ggtags-mode 1))))
+  :bind (:map ggtags-mode-map
+              ("C-c g s" . ggtags-find-other-symbol)
+              ("C-c g h" . ggtags-view-tag-history)
+              ("C-c g r" . ggtags-find-reference)
+              ("C-c g f" . ggtags-find-file)
+              ("C-c g c" . ggtags-create-tags)
+              ("C-c g u" . ggtags-update-tags)
+              ("M-," . pop-tag-mark)
+              )
+  :config
+  ;;integrating ggtags with imenue
+  (setq-local imenu-create-index-function #'ggtags-build-imenu-index))
+
+;; company-c-headers ( auto complete c header names )
+(require 'company-c-headers)
+(add-to-list 'company-backends 'company-c-headers)
+;; let company c headers also complete c++ headers
+(add-to-list 'company-c-headers-path-system "/usr/local/Cellar/gcc/11.2.0/include/c++/11.2.0")
+
+(provide 'init-cc)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-cc.el ends here

--- a/elisp/init-company.el
+++ b/elisp/init-company.el
@@ -1,0 +1,90 @@
+;;; init-company.el --- -*-lexical-binding: t -*-
+;;
+;; Filename: init-company.el
+;; Description: initialise company mode
+;; Author: Ankur Saini
+;; Maintainer:
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Mon Jun 20 12:59:59 2022 (+0530)
+;; Version: 1.0
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 5
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: company auto-complete .emacs.d
+;; Compatibility: emacs-version >= 26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This file initialise company mode package, which is the
+;; auto-complete packge I use in Emacs.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+(use-package company
+  :diminish company-mode
+  :hook ((prog-mode LaTeX-mode latex-mode ess-r-mode) . company-mode)
+  :bind
+  (:map company-active-map
+        ([tab] . smarter-tab-to-complete)
+        ("TAB" . smarter-tab-to-complete))
+  :custom
+  (company-minimum-prefix-length 1)
+  (company-tooltip-align-annotations t)
+  (company-require-match 'never)
+  ;; Don't use company in the following modes
+  (company-global-modes '(not shell-mode eaf-mode))
+  ;; Trigger completion immediately.
+  (company-idle-delay 0.1)
+  ;; Number the candidates (use M-1, M-2 etc to select completions).
+  (company-show-numbers t)
+  :config
+  ;;(unless clangd-p (delete 'company-clang company-backends))
+  (global-company-mode 1)
+  (defun smarter-tab-to-complete ()
+    "Try to `org-cycle', `yas-expand', and `yas-next-field' at current cursor position.
+
+If all failed, try to complete the common part with `company-complete-common'"
+    (interactive)
+    (when yas-minor-mode
+      (let ((old-point (point))
+            (old-tick (buffer-chars-modified-tick))
+            (func-list
+             (if (equal major-mode 'org-mode) '(org-cycle yas-expand yas-next-field)
+               '(yas-expand yas-next-field))))
+        (catch 'func-suceed
+          (dolist (func func-list)
+            (ignore-errors (call-interactively func))
+            (unless (and (eq old-point (point))
+                         (eq old-tick (buffer-chars-modified-tick)))
+              (throw 'func-suceed t)))
+          (company-complete-common))))))
+
+(provide 'init-company)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-company.el ends here

--- a/elisp/init-dashboard.el
+++ b/elisp/init-dashboard.el
@@ -1,0 +1,80 @@
+;;; init-dashboard.el --- -*- lexical-binding: t -*-
+;;
+;; Filename: init-dashboard.el
+;; Description: Initialize dashboard
+;; Author: Ankur Saini
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Mon Jun 20 10:22:47 2022 (+0530)
+;; Version: 1.0
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 9
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: dashboard .emacs.d
+;; Compatibility: emacs-version >= 26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This file initialize dashboard customisation
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+(use-package dashboard
+  :demand
+  :diminish (dashboard-mode page-break-lines-mode)
+  :bind
+  (("C-z d" . open-dashboard)
+   :map dashboard-mode-map
+   (("n" . dashboard-next-line)
+    ("p" . dashboard-previous-line)
+    ("N" . dashboard-next-section)
+    ("F" . dashboard-previous-section)))
+  :custom
+  (dashboard-set-heading-icons t)
+  (dashboard-set-navigator t)
+  :config
+  (dashboard-setup-startup-hook)
+    ;; Open Dashboard function
+  (defun open-dashboard ()
+    "Open the *dashboard* buffer and jump to the first widget."
+    (interactive)
+    (if (get-buffer dashboard-buffer-name)
+        (kill-buffer dashboard-buffer-name))
+    (dashboard-insert-startupify-lists)
+    (switch-to-buffer dashboard-buffer-name)
+    (goto-char (point-min))
+    (delete-other-windows)))
+
+;; to draw nice horizontal lines
+(use-package page-break-lines
+  :diminish
+  :init (global-page-break-lines-mode))
+
+(provide 'init-dashboard)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-dashboard.el ends here

--- a/elisp/init-dired.el
+++ b/elisp/init-dired.el
@@ -1,0 +1,95 @@
+;;; init-dired.el --- -*- lexical-binding: t -*-
+;;
+;; Filename: init-dired.el
+;; Description: initialize dired
+;; Author: Ankur Saini
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Sun Jun 19 18:32:40 2022 (+0530)
+;; Version: 1.0
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 16
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: dired .emacs.d
+;; Compatibility:
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This file initialise dired configuration.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+;;;;;;;;;;;;;;;;;;
+;; dired config ;;
+;;;;;;;;;;;;;;;;;;
+
+;; DiredPackage
+(use-package dired
+  :ensure nil
+  :bind
+  (("C-x C-j" . dired-jump))
+  :custom
+  ;; Use gnu's ls (macOS: install coreutils first)
+  (insert-directory-program "gls" dired-use-ls-dired t)
+  ;; Always delete and copy recursively
+  (dired-listing-switches "-agho --group-directories-first")
+  (dired-recursive-deletes 'always)
+  (dired-recursive-copies 'always)
+  ;; Auto refresh Dired, but be quiet about it
+  (global-auto-revert-non-file-buffers t)
+  (auto-revert-verbose nil)
+  ;; Quickly copy/move file in Dired
+  (dired-dwim-target t)
+  ;; Move files to trash when deleting
+  (delete-by-moving-to-trash t)
+  ;; Load the newest version of a file
+  (load-prefer-newer t)
+  ;; Detect external file changes and auto refresh file
+  (auto-revert-use-notify nil)
+  (auto-revert-interval 3) ; Auto revert every 3 sec
+  :config
+  ;; Enable global auto-revert
+  (global-auto-revert-mode t)
+  ;; Reuse same dired buffer, to prevent numerous buffers while navigating in dired
+  (put 'dired-find-alternate-file 'disabled nil)
+  :hook
+  (dired-mode . (lambda ()
+                  (local-set-key (kbd "<mouse-2>") #'dired-find-alternate-file)
+                  (local-set-key (kbd "RET") #'dired-find-alternate-file)
+                  (local-set-key (kbd "^")
+                                 (lambda () (interactive) (find-alternate-file ".."))))))
+
+(use-package dired-single)
+
+(use-package all-the-icons-dired
+  :hook (dired-mode . all-the-icons-dired-mode)
+  :init (setq all-the-icons-dired-monochrome nil))
+
+(provide 'init-dired)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-dired.el ends here

--- a/elisp/init-edit.el
+++ b/elisp/init-edit.el
@@ -1,0 +1,76 @@
+;;; init-edit.el --- -*- lexical-binding: t -*-
+;;
+;; Filename: init-edit.el
+;; Description: Initialize editing config
+;; Author: Ankur Saini
+;; Maintainer:
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Mon Jun 20 12:48:27 2022 (+0530)
+;; Version: 1.0
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 16
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: iedit .emacs.d edit ws-buttler clean-aindent
+;; Compatibility: emacs-version >=26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This file initialise packages related to editing file.
+;; Initialization include (iedit, we-buttler, clean-aident,
+;; multiple-cursors)
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+(eval-when-compile
+  (require 'init-global-config))
+
+;; Highlight and replace multiple occurances of a text in the buffer
+(use-package iedit
+  :diminish)
+
+;; clean auto-indent and backspace unindent
+(use-package clean-aindent-mode
+  :diminish
+  :hook (prog-mode . clean-aindent-mode))
+
+;; strip additional whitespaces at the end of lines
+(use-package ws-butler
+  :diminish
+  :hook (prog-mode . ws-butler-mode))
+
+
+(use-package multiple-cursors
+  :bind ( ("C-S-c C-S-c" . mc/edit-lines)
+          ( "C->" . mc/mark-next-like-this)
+          ("C-<" . mc/mark-previous-like-this)
+          ("C-c C-<". mc/mark-all-like-this)))
+
+(provide 'init-edit)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-edit.el ends here

--- a/elisp/init-elcord.el
+++ b/elisp/init-elcord.el
@@ -1,0 +1,54 @@
+;;; init-elcord.el --- -*-lexical-binding: t -*-
+;;
+;; Filename: init-elcord.el
+;; Description: Initialise elcord
+;; Author: Ankur Saini
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Mon Jun 20 13:27:16 2022 (+0530)
+;; Version: 1.0
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 7
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: elcord discord .emacs.d
+;; Compatibility: emacs-version >= 26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This file initialise elcord mode package, which provides discord
+;; rpc for the mighty Emacs.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+;; discord rpc for emacs
+(use-package elcord
+  :init (elcord-mode))
+
+(provide 'init-elcord)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-elcord.el ends here

--- a/elisp/init-font.el
+++ b/elisp/init-font.el
@@ -1,0 +1,59 @@
+;;; init-font.el --- -*- lexical-binding: t -*-
+;;
+;; Filename: init-font.el
+;; Description: Initialize font configuration
+;; Author: Ankur Saini
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Mon Jun 20 10:14:20 2022 (+0530)
+;; Version: 1.0
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 9
+;; URL:  https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: font .emacs.d
+;; Compatibility: emacs-version >= 26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This file initialise Font configurations of Emacs.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+(defvar arsenic/default-font-size 150)
+
+(set-face-attribute 'default nil :font "Fira Code" :height arsenic/default-font-size)
+
+;; Set the fixed pitch face
+(set-face-attribute 'fixed-pitch nil :font "Fira Code" :height 150)
+
+;; Set the variable pitch face
+(set-face-attribute 'variable-pitch nil :font "Cantarell" :height 152 :weight 'regular)
+
+(provide 'init-font)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-font.el ends here

--- a/elisp/init-git.el
+++ b/elisp/init-git.el
@@ -1,0 +1,68 @@
+;;; init-git.el --- -*-lexical-binding: t -*-
+;;
+;; Filename: init-git.el
+;; Description: Initialize magit
+;; Author: Ankur Saini
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Mon Jun 20 10:41:08 2022 (+0530)
+;; Version: 1.0
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 10
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: magit .emacs.d
+;; Compatibility: emacs-version >=26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This file initialize magit package, which is amazing git
+;; integration for Emacs.Configuration for diff-hl and other packages
+;; related to git also exist in this file.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+
+(use-package magit
+  :custom
+  (magit-display-buffer-function #'magit-display-buffer-same-window-except-diff-v1)
+  :bind
+  ((:map magit-status-mode-map
+    ("M-RET" . magit-diff-visit-file-other-window))))
+
+
+;; highlights uncommitted changes on the left side of the window
+(use-package diff-hl
+  :init
+  (global-diff-hl-mode)  ;; enable it globally
+  (diff-hl-margin-mode)  ;; display changes in margin instead of gutter
+  (diff-hl-flydiff-mode) ;; show hl on the fly
+  )
+
+(provide 'init-git)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-git.el ends here

--- a/elisp/init-global-config.el
+++ b/elisp/init-global-config.el
@@ -9,7 +9,7 @@
 ;; Package-Requires: ()
 ;; Last-Updated:
 ;;           By:
-;;     Update #: 41
+;;     Update #: 43
 ;; URL: https://github.com/Arsenic-ATG/Emacs-config
 ;; Keywords: .emacs.d global-config
 ;; Compatibility: emacs-version >= 26.1
@@ -44,9 +44,6 @@
 ;;
 ;;; Code:
 
-;; Auto-revert Dired and other buffers
-(setq global-auto-revert-non-file-buffers t)
-
 ;; Replace active region by typing text
 (delete-selection-mode 1)
 
@@ -57,7 +54,6 @@
 ;; Unbind unneeded keys
 (global-set-key (kbd "C-z") nil)
 (global-set-key (kbd "M-z") nil)
-(global-set-key (kbd "M-m") nil)
 (global-set-key (kbd "C-x C-z") nil)
 (global-set-key (kbd "M-/") nil)
 ;; Truncate lines

--- a/elisp/init-global-config.el
+++ b/elisp/init-global-config.el
@@ -1,0 +1,120 @@
+;;; init-global-config.el --- -*- lexical-binding: t -*-
+;;
+;; Filename: init-global-config.el
+;; Description: Initialise global configuration
+;; Author: Ankur Saini
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Sun Jun 19 14:00:20 2022 (+0530)
+;; Version: 1.0
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 41
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: .emacs.d global-config
+;; Compatibility: emacs-version >= 26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This file initializes the global confgiruations of Emacs
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+;; Auto-revert Dired and other buffers
+(setq global-auto-revert-non-file-buffers t)
+
+;; Replace active region by typing text
+(delete-selection-mode 1)
+
+;;;;;;;;;;;;;;;;;;;;;
+;; Global Bindings ;;
+;;;;;;;;;;;;;;;;;;;;;
+
+;; Unbind unneeded keys
+(global-set-key (kbd "C-z") nil)
+(global-set-key (kbd "M-z") nil)
+(global-set-key (kbd "M-m") nil)
+(global-set-key (kbd "C-x C-z") nil)
+(global-set-key (kbd "M-/") nil)
+;; Truncate lines
+(global-set-key (kbd "C-x C-l") #'toggle-truncate-lines)
+;; Adjust font size like web browsers
+(global-set-key (kbd "C-=") #'text-scale-increase)
+(global-set-key (kbd "C-+") #'text-scale-increase)
+(global-set-key (kbd "C--") #'text-scale-decrease)
+;; Move up/down paragraph
+(global-set-key (kbd "M-n") #'forward-paragraph)
+(global-set-key (kbd "M-p") #'backward-paragraph)
+;; Switching windows using M-o
+(global-set-key (kbd "M-o") 'other-window)
+;; Make ESC quit prompts
+(global-set-key (kbd "<escape>") 'keyboard-escape-quit)
+;; Activate whitespace-mode to view all whitespace characters
+(global-set-key (kbd "C-c w") 'whitespace-mode)
+
+;;;;;;;;;;;;;;;;;;;
+;; Small Configs ;;
+;;;;;;;;;;;;;;;;;;;
+
+;; keep all the mess(backup files) at one place
+(setq backup-directory-alist '(("." . "~/.emacs.d/backup"))
+  backup-by-copying t    ; Don't delink hardlinks
+  version-control t      ; Use version numbers on backups
+  delete-old-versions t  ; Automatically delete excess backups
+  kept-new-versions 20   ; how many of the newest versions to keep
+  kept-old-versions 5    ; and how many of the old
+  )
+
+;; Ask before killing emacs
+(setq confirm-kill-emacs 'y-or-n-p)
+
+
+;; Automatically kill all active processes when closing Emacs
+(setq confirm-kill-processes nil)
+
+;; Turn Off Cursor Alarms
+(setq ring-bell-function 'ignore)
+
+;; Better Compilation
+(setq-default compilation-always-kill t) ; kill compilation process
+                                         ; before starting another
+
+(setq-default compilation-ask-about-save nil) ; save all buffers on
+                                              ; `compile'
+
+(setq-default compilation-scroll-output t)
+
+;; Move customization variables to a separate file and load it
+(setq custom-file (locate-user-emacs-file "custom-vars.el"))
+(load custom-file 'noerror 'nomessage)
+
+;; Add a newline automatically at the end of the file upon save.
+(setq require-final-newline t)
+
+(provide 'init-global-config)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-global-config.el ends here

--- a/elisp/init-header.el
+++ b/elisp/init-header.el
@@ -1,0 +1,60 @@
+;;; init-header.el --- -*-lexical-binding: t -*-
+;;
+;; Filename: init-header.el
+;; Description: Initialise header2
+;; Author: Ankur Saini
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Mon Jun 20 12:56:34 2022 (+0530)
+;; Version: 1.0
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 5
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: header header2 .emacs.d
+;; Compatibility: emacs-version >= 26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This file initialise header2 (package used to generate header for
+;; elisp files)
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+(use-package header2
+  :load-path (lambda () (expand-file-name "non-melpa-elisp/header2" user-emacs-directory))
+  :custom
+  (header-copyright-notice (concat "Copyright (C) 2019 " (user-full-name) "\n"))
+  :hook (emacs-lisp-mode . auto-make-header)
+  :config
+  (add-to-list 'write-file-functions 'auto-update-file-header)
+  (autoload 'auto-make-header "header2")
+  (autoload 'auto-update-file-header "header2"))
+
+(provide 'init-header)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-header.el ends here

--- a/elisp/init-helpful.el
+++ b/elisp/init-helpful.el
@@ -1,0 +1,60 @@
+;;; init-helpful.el --- -*-lexical-binding: t-*-
+;;
+;; Filename: init-helpful.el
+;; Description: Initialise helpful package
+;; Author: Ankur Saini
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Mon Jun 20 13:24:55 2022 (+0530)
+;; Version: 1.0
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 5
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: helpful .emacs.d
+;; Compatibility: emacs-version >= 26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This file initialise "helpful" package, a package that enhacnes the
+;; already awesome documentation of Emacs.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+(use-package helpful
+  :custom
+  (counsel-describe-function-function #'helpful-callable)
+  (counsel-describe-variable-function #'helpful-variable)
+  :bind
+  ([remap describe-function] . counsel-describe-function)
+  ([remap describe-command] . helpful-command)
+  ([remap describe-variable] . counsel-describe-variable)
+  ([remap describe-key] . helpful-key))
+
+(provide 'init-helpful)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-helpful.el ends here

--- a/elisp/init-indent.el
+++ b/elisp/init-indent.el
@@ -1,0 +1,77 @@
+;;; init-indent.el --- -*-lexical-binding: t -*-
+;;
+;; Filename: init-indent.el
+;; Description: Initialise indentation
+;; Author: Ankur Saini
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Mon Jun 20 11:18:56 2022 (+0530)
+;; Version: 1.0
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 11
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: indent .emacs.d dtrt-indent
+;; Compatibility: emacs-version >= 26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This file initialize common indentation confguration for all
+;; programming languages and dtrt-indent package (indentation specific
+;; to a programming langauge can be found in their own seperate init
+;; file)
+;; 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+;; use space to indent by default
+(setq-default indent-tabs-mode nil)
+(setq-default indent-line-function 'insert-tab)
+(setq-default tab-width 8)
+(c-set-offset 'comment-intro 0)
+(c-set-offset 'innamespace 0)
+(c-set-offset 'case-label '+)
+(c-set-offset 'access-label 0)
+(c-set-offset (quote cpp-macro) 0 nil)
+(defun smart-electric-indent-mode ()
+  "Disable 'electric-indent-mode in certain buffers and enable otherwise."
+  (cond ((and (eq electric-indent-mode t)
+              (member major-mode '(erc-mode text-mode)))
+         (electric-indent-mode 0))
+        ((eq electric-indent-mode nil) (electric-indent-mode 1))))
+(add-hook 'post-command-hook #'smart-electric-indent-mode)
+
+;; tab to indent and autocomplete
+(setq tab-always-indent 'complete)
+
+;; dtrt-indent: to detect and set indend offset depending on the file being edited
+(use-package dtrt-indent
+  :diminish
+  :init (dtrt-indent-global-mode))
+
+(provide 'init-indent)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-indent.el ends here

--- a/elisp/init-markdown.el
+++ b/elisp/init-markdown.el
@@ -1,0 +1,54 @@
+;;; init-markdown.el --- -*-lexical-binding: t -*-
+;;
+;; Filename: init-markdown.el
+;; Description: Initialise markdown mode
+;; Author: Ankur Saini
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Mon Jun 20 13:37:25 2022 (+0530)
+;; Version:
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 4
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: markdown md .emacs.d
+;; Compatibility: emacs-version >= 26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; this file set up initial configuration of markdown mode.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+(use-package markdown-mode
+  :mode ("README\\.md\\'" . gfm-mode)
+  :init (setq markdown-command "multimarkdown"))
+
+
+(provide 'init-markdown)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-markdown.el ends here

--- a/elisp/init-org.el
+++ b/elisp/init-org.el
@@ -1,0 +1,114 @@
+;;; init-org.el --- -*- lexical-binding: t -*-
+;;
+;; Filename: init-org.el
+;; Description: Initialise org mode
+;; Author: Ankur Saini
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Mon Jun 20 13:34:55 2022 (+0530)
+;; Version:
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 7
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: org .emacs.d
+;; Compatibility: eamcs-version >= 26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This file set up initial configuration of ORG mode for Emacs
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+(defun efs/org-mode-setup ()
+  (org-indent-mode)
+  (variable-pitch-mode 1)
+  (visual-line-mode 1))
+
+(defun efs/org-font-setup ()
+  ;; Replace list hyphen with dot
+  (font-lock-add-keywords 'org-mode
+                          '(("^ *\\([-]\\) "
+                             (0 (prog1 () (compose-region (match-beginning 1) (match-end 1) "•"))))))
+
+  ;; Set faces for heading levels
+  (dolist (face '((org-level-1 . 1.2)
+                  (org-level-2 . 1.1)
+                  (org-level-3 . 1.05)
+                  (org-level-4 . 1.0)
+                  (org-level-5 . 1.1)
+                  (org-level-6 . 1.1)
+                  (org-level-7 . 1.1)
+                  (org-level-8 . 1.1)))
+    (set-face-attribute (car face) nil :font "Cantarell" :weight 'regular :height (cdr face)))
+
+  ;; Ensure that anything that should be fixed-pitch in Org files appears that way
+  (set-face-attribute 'org-block nil :foreground nil :inherit 'fixed-pitch)
+  (set-face-attribute 'org-code nil   :inherit '(shadow fixed-pitch))
+  (set-face-attribute 'org-table nil   :inherit '(shadow fixed-pitch))
+  (set-face-attribute 'org-verbatim nil :inherit '(shadow fixed-pitch))
+  (set-face-attribute 'org-special-keyword nil :inherit '(font-lock-comment-face fixed-pitch))
+  (set-face-attribute 'org-meta-line nil :inherit '(font-lock-comment-face fixed-pitch))
+  (set-face-attribute 'org-checkbox nil :inherit 'fixed-pitch))
+
+(use-package org
+  :hook (org-mode . efs/org-mode-setup)
+  :config
+  (setq org-ellipsis " ▾")
+
+  (setq org-agenda-start-with-log-mode t)
+  (setq org-log-done 'time)
+  (setq org-log-into-drawer t)
+
+  ;; Save Org buffers after refiling!
+  (advice-add 'org-refile :after 'org-save-all-org-buffers))
+
+(use-package org-bullets
+  :after org
+  :hook (org-mode . org-bullets-mode)
+  :custom
+  (org-bullets-bullet-list '("◉" "○" "●" "○" "●" "○" "●")))
+
+(defun efs/org-mode-visual-fill ()
+  (setq visual-fill-column-width 100
+        visual-fill-column-center-text t)
+  (visual-fill-column-mode 1))
+
+(use-package visual-fill-column
+  :hook (org-mode . efs/org-mode-visual-fill))
+
+;; This is needed as of Org 9.2
+(require 'org-tempo)
+
+(add-to-list 'org-structure-template-alist '("sh" . "src shell"))
+(add-to-list 'org-structure-template-alist '("el" . "src emacs-lisp"))
+(add-to-list 'org-structure-template-alist '("py" . "src python"))
+(add-to-list 'org-structure-template-alist '("cpp" . "src cpp"))
+
+(provide 'init-org)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-org.el ends here

--- a/elisp/init-package.el
+++ b/elisp/init-package.el
@@ -1,0 +1,98 @@
+;;; init-package.el --- -*- lexical-binding: t -*-
+;;
+;; Filename: init-package.el
+;; Description: Initialize package manager
+;; Author: Ankur Saini
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Sun Jun 19 14:43:55 2022 (+0530)
+;; Version: 1.0
+;; Last-Updated:
+;;           By:
+;;     Update #: 26
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: packages use-package .emacs.d
+;; Compatibility: emacs-version >= 26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This file initialise and configure packages from ELPA repositories,
+;; use-package setup and diminish
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+
+(require 'package)
+
+;; Initialize package resources
+(setq package-archives
+      '(("GNU" . "http://elpa.gnu.org/packages/")
+        ("MELPA" . "http://melpa.org/packages/")
+        ("nonGNU" . "https://elpa.nongnu.org/nongnu/")
+	("MELPA Stable" . "http://stable.melpa.org/packages/")))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Package manager config ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(unless (bound-and-true-p package--initialized)
+  (setq package-enable-at-startup nil)          ; To prevent initializing twice
+  (package-initialize))
+
+;; set use-package-verbose to t for interpreted .emacs,
+;; and to nil for byte-compiled .emacs.elc.
+(eval-and-compile
+  (setq use-package-verbose (not (bound-and-true-p byte-compile-current-file))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;
+;; Use-Package config ;;
+;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Install use-package if not installed
+(unless (package-installed-p 'use-package)
+  (package-refresh-contents)
+  (package-install 'use-package))
+
+(eval-and-compile
+  (setq use-package-always-ensure t)
+  (setq use-package-expand-minimally t)
+  (setq use-package-compute-statistics t)
+  (setq use-package-enable-imenu-support t))
+
+(eval-when-compile
+  (require 'use-package)
+  (require 'bind-key))
+
+;;;;;;;;;;;;;;
+;; diminish ;;
+;;;;;;;;;;;;;;
+
+;; to remove certain minor modes from modeline
+(use-package diminish)
+
+(provide 'init-package)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-package.el ends here

--- a/elisp/init-parens.el
+++ b/elisp/init-parens.el
@@ -1,0 +1,87 @@
+;;; init-parens.el --- -*-lexical-binding: t -*-
+;;
+;; Filename: init-parens.el
+;; Description: Initialise parenthesis
+;; Author: Ankur Saini
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Mon Jun 20 11:10:27 2022 (+0530)
+;; Version: 1.0
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 8
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: parenthesis smartprens rainbow-delimiter .emacs.d
+;; Compatibility: emacs-version >= 26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This File initialise every package related to parenthesis.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+;;;;;;;;;;;;;;;;;
+;; Smartparens ;;
+;;;;;;;;;;;;;;;;;
+
+(use-package smartparens
+  :hook (prog-mode . smartparens-mode)
+  :diminish smartparens-mode
+  :bind
+  (:map smartparens-mode-map
+        ("C-M-f" . sp-forward-sexp)
+        ("C-M-b" . sp-backward-sexp)
+        ("C-M-a" . sp-backward-down-sexp)
+        ("C-M-e" . sp-up-sexp)
+        ("C-M-w" . sp-copy-sexp)
+        ("C-M-k" . sp-change-enclosing)
+        ("M-k" . sp-kill-sexp)
+        ("C-M-<backspace>" . sp-splice-sexp-killing-backward)
+        ("C-S-<backspace>" . sp-splice-sexp-killing-around)
+        ("C-]" . sp-select-next-thing-exchange))
+  :custom
+  (sp-escape-quotes-after-insert nil)
+  :config
+  ;; Stop pairing single quotes in elisp
+  (sp-local-pair 'emacs-lisp-mode "'" nil :actions nil)
+  (sp-local-pair 'org-mode "[" nil :actions nil)
+;; on RET press, the curly braces automatically add another newline
+  (sp-with-modes '(c-mode c++-mode)
+    (sp-local-pair "{" nil :post-handlers '(("||\n[i]" "RET")))
+    (sp-local-pair "/*" "*/" :post-handlers '((" | " "SPC")
+                                              ("* ||\n[i]" "RET")))))
+
+;; Show matching parenthesis
+(show-paren-mode 1)
+
+;; Delimiters at different level ahve different color
+(use-package rainbow-delimiters
+  :hook (prog-mode . rainbow-delimiters-mode))
+
+(provide 'init-parens)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-parens.el ends here

--- a/elisp/init-projectile.el
+++ b/elisp/init-projectile.el
@@ -51,8 +51,7 @@
   :bind-keymap
   ("C-c p" . projectile-command-map)
   :init
-  (setq projectile-switch-project-action #'projectile-dired)
-  (add-to-list 'projectile-globally-ignored-directories "node_modules"))
+  (setq projectile-switch-project-action #'projectile-dired))
 
 (use-package counsel-projectile
   :config (counsel-projectile-mode))

--- a/elisp/init-projectile.el
+++ b/elisp/init-projectile.el
@@ -1,0 +1,62 @@
+;;; init-projectile.el --- -*-lexical-binding: t -*-
+;;
+;; Filename: init-projectile.el
+;; Description: Initialize projectile
+;; Author: Ankur Saini
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Mon Jun 20 10:46:41 2022 (+0530)
+;; Version: 1.0
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 5
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: .emacs.d projectile
+;; Compatibility: emacs-version >= 26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This file initialise projectile;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+(use-package projectile
+  :diminish projectile-mode
+  :config (projectile-mode)
+  :custom ((projectile-completion-system 'ivy))
+  :bind-keymap
+  ("C-c p" . projectile-command-map)
+  :init
+  (setq projectile-switch-project-action #'projectile-dired)
+  (add-to-list 'projectile-globally-ignored-directories "node_modules"))
+
+(use-package counsel-projectile
+  :config (counsel-projectile-mode))
+
+(provide 'init-projectile)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-projectile.el ends here

--- a/elisp/init-search.el
+++ b/elisp/init-search.el
@@ -1,0 +1,82 @@
+;;; init-search.el --- -*- lexical-binding: t -*-
+;;
+;; Filename: init-search.el
+;; Description: Initialize packages for searching
+;; Author: Ankur Saini
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Sun Jun 19 17:38:50 2022 (+0530)
+;; Version: 1.0
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 15
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: .emacs.d ivy
+;; Compatibility: emacs-version >= 26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This file contains initialization of packages that deal with
+;; searching (ivy, swiper, counsel)
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+(eval-when-compile
+  (require 'init-global-config))
+
+
+(use-package swiper :ensure t)
+
+(use-package ivy
+  :diminish
+  :bind (("C-s" . swiper)
+         :map ivy-minibuffer-map
+         ("TAB" . ivy-alt-done)
+         ("C-l" . ivy-alt-done)
+         ("C-j" . ivy-next-line)
+         ("C-k" . ivy-previous-line)
+         :map ivy-switch-buffer-map
+         ("C-k" . ivy-previous-line)
+         ("C-l" . ivy-done)
+         ("C-d" . ivy-switch-buffer-kill)
+         :map ivy-reverse-i-search-map
+         ("C-k" . ivy-previous-line)
+         ("C-d" . ivy-reverse-i-search-kill))
+  :config
+  (ivy-mode 1))
+
+(use-package find-file-in-project
+  :if (executable-find "find")
+  :init
+  (when (executable-find "fd")
+    (setq ffip-use-rust-fd t))
+  :bind (("C-z o" . ffap)
+         ("C-z p" . ffip)))
+
+(provide 'init-search)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-search.el ends here

--- a/elisp/init-search.el
+++ b/elisp/init-search.el
@@ -9,9 +9,9 @@
 ;; Package-Requires: ()
 ;; Last-Updated:
 ;;           By:
-;;     Update #: 15
+;;     Update #: 19
 ;; URL: https://github.com/Arsenic-ATG/Emacs-config
-;; Keywords: .emacs.d ivy
+;; Keywords: .emacs.d ivy counsel swiper
 ;; Compatibility: emacs-version >= 26.1
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -19,7 +19,7 @@
 ;;; Commentary:
 ;;
 ;; This file contains initialization of packages that deal with
-;; searching (ivy, swiper, counsel)
+;; searching (ivy, swiper, counsel, ivy-rich)
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
@@ -48,6 +48,7 @@
 (eval-when-compile
   (require 'init-global-config))
 
+(setq apropos-sort-by-scores t)
 
 (use-package swiper :ensure t)
 
@@ -76,6 +77,23 @@
     (setq ffip-use-rust-fd t))
   :bind (("C-z o" . ffap)
          ("C-z p" . ffip)))
+
+(use-package all-the-icons-ivy-rich
+  :after counsel-projectile
+  :init (all-the-icons-ivy-rich-mode +1))
+
+(use-package ivy-rich
+  :ensure t
+  :after (counsel)
+  :config (ivy-rich-mode 1))
+
+(use-package counsel
+  :bind (("M-x" . counsel-M-x)
+         ("C-x b" . counsel-ibuffer)
+         ("C-x C-f" . counsel-find-file)
+         :map minibuffer-local-map
+         ("C-r" . 'counsel-minibuffer-history)))
+
 
 (provide 'init-search)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/elisp/init-syntax.el
+++ b/elisp/init-syntax.el
@@ -1,0 +1,118 @@
+;;; init-syntax.el --- -*-lexical-binding: t -*-
+;;
+;; Filename: init-syntax.el
+;; Description: Initialize syntax checking
+;; Author: Ankur Saini
+;; Maintainer:
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Mon Jun 20 10:58:25 2022 (+0530)
+;; Version:
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 9
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: flycheck flyspell syntax .emacs.d
+;; Compatibility: emacs-version >=26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This file initialize syntax packages responsible for syntax
+;; checking (flycheck and flyspell)
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+;;;;;;;;;;;;;;;;;;;;;
+;; Flycheck config ;;
+;;;;;;;;;;;;;;;;;;;;;
+
+(use-package flycheck
+  :defer t
+  :diminish
+  :hook (after-init . global-flycheck-mode)
+  :commands (flycheck-add-mode)
+  :custom
+  (flycheck-global-modes
+   '(not outline-mode diff-mode shell-mode eshell-mode term-mode))
+  (flycheck-emacs-lisp-load-path 'inherit)
+  (flycheck-indication-mode (if (display-graphic-p) 'right-fringe 'right-margin))
+  :init
+  (if (display-graphic-p)
+      (use-package flycheck-posframe
+        :custom-face
+        (flycheck-posframe-face ((t (:foreground ,(face-foreground 'success)))))
+        (flycheck-posframe-info-face ((t (:foreground ,(face-foreground 'success)))))
+        :hook (flycheck-mode . flycheck-posframe-mode)
+        :custom
+        (flycheck-posframe-position 'window-bottom-left-corner)
+        (flycheck-posframe-border-width 3)
+        (flycheck-posframe-inhibit-functions
+         '((lambda (&rest _) (bound-and-true-p company-backend)))))
+    (use-package flycheck-pos-tip
+      :defines flycheck-pos-tip-timeout
+      :hook (flycheck-mode . flycheck-pos-tip-mode)
+      :custom (flycheck-pos-tip-timeout 30)))
+  :config
+  (use-package flycheck-popup-tip
+    :hook (flycheck-mode . flycheck-popup-tip-mode))
+  (when (fboundp 'define-fringe-bitmap)
+    (define-fringe-bitmap 'flycheck-fringe-bitmap-double-arrow
+      [16 48 112 240 112 48 16] nil nil 'center))
+  (when (executable-find "vale")
+    (use-package flycheck-vale
+      :config
+      (flycheck-vale-setup)
+      (flycheck-add-mode 'vale 'latex-mode)))
+  (add-hook 'c++-mode-hook
+            (lambda () (setq flycheck-clang-language-standard "c++2a"))))
+
+;;;;;;;;;;;;;;;;;;;;;
+;; Flyspell config ;;
+;;;;;;;;;;;;;;;;;;;;;
+
+(use-package flyspell
+  :ensure nil
+  :diminish
+  :if (executable-find "aspell")
+  :hook (((text-mode outline-mode latex-mode org-mode markdown-mode) . flyspell-mode))
+  :custom
+  (flyspell-issue-message-flag nil)
+  (ispell-program-name "aspell")
+  (ispell-extra-args
+   '("--sug-mode=ultra" "--lang=en_US" "--camel-case"))
+  :config
+  (use-package flyspell-correct-ivy
+    :after ivy
+    :bind
+    (:map flyspell-mode-map
+          ([remap flyspell-correct-word-before-point] . flyspell-correct-wrapper)
+          ("C-." . flyspell-correct-wrapper))
+    :custom (flyspell-correct-interface #'flyspell-correct-ivy)))
+
+(provide 'init-syntax)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-syntax.el ends here

--- a/elisp/init-theme.el
+++ b/elisp/init-theme.el
@@ -1,0 +1,91 @@
+;;; init-theme.el ---  -*- lexical-binding: t -*-
+;;
+;; Filename: init-theme.el
+;; Description: Initialize themes
+;; Author: Ankur Saini
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Mon Jun 20 10:09:13 2022 (+0530)
+;; Version: 1.0
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 12
+;; URL:  https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: theme .emacs.d
+;; Compatibility: emacs-version >= 26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This file initialize the theme configuration of Emacs.The current
+;; configuration use Doom themes and Doom modeline
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+
+;;;;;;;;;;;;;;;;;;;;;;;
+;; Doom theme config ;;
+;;;;;;;;;;;;;;;;;;;;;;;
+
+(use-package doom-themes
+  :custom-face
+  (cursor ((t (:background "BlanchedAlmond"))))
+  :config
+  ;; flashing mode-line on errors
+  (doom-themes-visual-bell-config)
+  ;; Corrects (and improves) org-mode's native fontification.
+  (doom-themes-org-config)
+  (load-theme 'doom-one t)
+  (defun switch-theme ()
+    "An interactive funtion to switch themes."
+    (interactive)
+    (disable-theme (intern (car (mapcar #'symbol-name custom-enabled-themes))))
+    (call-interactively #'load-theme)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Doom modeline config ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; All the icons to collect various icon fonts (Enable only in GUI emacs)
+;; all the icons required for doom-modeline to work properly
+(use-package all-the-icons :if (display-graphic-p))
+
+;; modeline of omega doom
+(use-package doom-modeline
+  :custom
+  ;; Don't compact font caches during GC. Windows Laggy Issue
+  (inhibit-compacting-font-caches t)
+  (doom-modeline-minor-modes t)
+  (doom-modeline-icon t)
+  (doom-modeline-major-mode-color-icon t)
+  (doom-modeline-height 15)
+  :config
+  (doom-modeline-mode))
+
+
+(provide 'init-theme)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-theme.el ends here

--- a/elisp/init-ui-config.el
+++ b/elisp/init-ui-config.el
@@ -1,0 +1,94 @@
+;;; init-ui-config.el ---  -*- lexical-binding: t -*-
+;;
+;; Filename: init-ui-config.el
+;; Description: Initialise ui configuration
+;; Author: Ankur Saini
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Mon Jun 20 09:58:41 2022 (+0530)
+;; Version: 1.0
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 18
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: .emacs.d ui
+;; Compatibility: emacs-version >= 26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This file initialise UI of the Emacs
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+;; Clean UI
+(setq inhibit-startup-message t)
+
+(scroll-bar-mode -1)        ; Disable visible scrollbar
+(tool-bar-mode -1)          ; Disable the toolbar
+(tooltip-mode -1)           ; Disable tooltips
+(set-fringe-mode 10)        ; Give some breathing room
+
+;; Use "y/n" instead of "yes/no" prompt
+(fset 'yes-or-no-p 'y-or-n-p)
+(setq use-dialog-box nil)
+
+;; Display line number and colum number
+(column-number-mode)
+(global-display-line-numbers-mode t)
+
+;; Disable line numbers for some modes
+(dolist (mode '(org-mode-hook
+                term-mode-hook
+                shell-mode-hook
+                eshell-mode-hook))
+  (add-hook mode (lambda () (display-line-numbers-mode 0))))
+
+;; Display time and battery status in modeline
+(display-time-mode 1)
+(display-battery-mode 1)
+
+;;;;;;;;;;;;;;;;;;;;;;
+;; Smooth scrolling ;;
+;;;;;;;;;;;;;;;;;;;;;;
+
+;; Vertical Scroll
+(setq scroll-step 1)
+(setq scroll-margin 1)
+(setq scroll-conservatively 101)
+(setq scroll-up-aggressively 0.01)
+(setq scroll-down-aggressively 0.01)
+(setq auto-window-vscroll nil)
+(setq fast-but-imprecise-scrolling nil)
+(setq mouse-wheel-scroll-amount '(1 ((shift) . 1)))
+(setq mouse-wheel-progressive-speed nil)
+;; Horizontal Scroll
+(setq hscroll-step 1)
+(setq hscroll-margin 1)
+
+(provide 'init-ui-config)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-ui-config.el ends here

--- a/elisp/init-which-key.el
+++ b/elisp/init-which-key.el
@@ -1,0 +1,64 @@
+;;; init-which-key.el --- -*- lexical-binding: t -*-
+;;
+;; Filename: init-which-key.el
+;; Description: initialise which-key
+;; Author: Ankur Saini
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Sun Jun 19 18:19:03 2022 (+0530)
+;; Version: 1.0
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 13
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: which-key .emacs.d
+;; Compatibility: emacs-version >= 26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;;  Initialise which-key package, which displays the key bindings
+;;  following your currently entered incomplete command (a prefix) in
+;;  a popup
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+;;;;;;;;;;;;;;;;;;;;;;
+;; Which key config ;;
+;;;;;;;;;;;;;;;;;;;;;;
+
+(use-package which-key
+  :diminish
+  :custom
+  (which-key-separator " ")
+  (which-key-prefix-prefix "+")
+  :config
+  (which-key-mode)
+  (setq which-key-idle-delay 0.5))
+
+(provide 'init-which-key)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-which-key.el ends here

--- a/elisp/init-yasnippets.el
+++ b/elisp/init-yasnippets.el
@@ -1,0 +1,71 @@
+;;; init-yasnippets.el --- -*-lexical-binding: t -*-
+;;
+;; Filename: init-yasnippets.el
+;; Description: initialize YAsnippets
+;; Author: Ankur Saini
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Mon Jun 20 10:53:55 2022 (+0530)
+;; Version: 1.0
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 5
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: Yasnippets .emacs.d
+;; Compatibility: emacs-version >= 26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This file initialise yasnippet config.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+(use-package yasnippet
+  :diminish yas-minor-mode
+  :init
+  (use-package yasnippet-snippets :after yasnippet)
+  :hook ((prog-mode LaTeX-mode org-mode markdown-mode) . yas-minor-mode)
+  :bind
+  (:map yas-minor-mode-map ("C-c C-n" . yas-expand-from-trigger-key))
+  (:map yas-keymap
+        (("TAB" . smarter-yas-expand-next-field)
+         ([(tab)] . smarter-yas-expand-next-field)))
+  :config
+  (yas-reload-all)
+  (defun smarter-yas-expand-next-field ()
+    "Try to `yas-expand' then `yas-next-field' at current cursor position."
+    (interactive)
+    (let ((old-point (point))
+          (old-tick (buffer-chars-modified-tick)))
+      (yas-expand)
+      (when (and (eq old-point (point))
+                 (eq old-tick (buffer-chars-modified-tick)))
+        (ignore-errors (yas-next-field))))))
+
+(provide 'init-yasnippets)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-yasnippets.el ends here

--- a/init.el
+++ b/init.el
@@ -367,6 +367,7 @@
 
 ;; dtrt-indent: to detect and set indend offset depending on the file being edited
 (use-package dtrt-indent
+  :diminish
   :init (dtrt-indent-global-mode))
 
 ;; Highlight and replace multiple occurances of a text in the buffer

--- a/init.el
+++ b/init.el
@@ -1,5 +1,54 @@
-(defun update-to-load-path (folder)
-  "Update FOLDER and its subdirectories to `load-path'."
+;;; init.el --- -*- lexical-binding: t -*-
+;;
+;; Filename: init.el
+;; Description: initialization file
+;; Author: Ankur Saini
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Sun Jun 19 13:31:54 2022 (+0530)
+;; Version: 1.0
+;; Last-Updated:
+;;           By:
+;;     Update #: 76
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: init .emacs.d
+;; Compatibility: emacs-version >= 26.1
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; Emacs initialization file ( or init file for short)
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+;;;;;;;;;;;;;;;
+;; Load path ;;
+;;;;;;;;;;;;;;;
+
+(defun add-to-load-path (folder)
+  "Add FOLDER and its subdirectories to `load-path'."
   (let ((base folder))
     (unless (member base load-path)
       (add-to-list 'load-path base))
@@ -11,549 +60,85 @@
           (unless (member base load-path)
             (add-to-list 'load-path name)))))))
 
-(update-to-load-path (expand-file-name "elisp" user-emacs-directory))
-
-;; Move customization variables to a separate file and load it
-(setq custom-file (locate-user-emacs-file "custom-vars.el"))
-(load custom-file 'noerror 'nomessage)
-
-;; Revert Dired and other buffers
-(setq global-auto-revert-non-file-buffers t)
-
-;; Switching windows using M-o
-(global-set-key (kbd "M-o") 'other-window)
-
-;; keep all the mess at one place
-(setq backup-directory-alist '(("." . "~/.emacs.d/backup"))
-  backup-by-copying t    ; Don't delink hardlinks
-  version-control t      ; Use version numbers on backups
-  delete-old-versions t  ; Automatically delete excess backups
-  kept-new-versions 20   ; how many of the newest versions to keep
-  kept-old-versions 5    ; and how many of the old
-  )
-
-;; Make ESC quit prompts
-(global-set-key (kbd "<escape>") 'keyboard-escape-quit)
-
-(windmove-default-keybindings)
-
-(defvar arsenic/default-font-size 150)
-
-;; Clean UI
-(setq inhibit-startup-message t)
-
-(scroll-bar-mode -1)        ; Disable visible scrollbar
-(tool-bar-mode -1)          ; Disable the toolbar
-(tooltip-mode -1)           ; Disable tooltips
-(set-fringe-mode 10)        ; Give some breathing room
-
-(display-time-mode 1)
-(display-battery-mode 1)
-
-;; Vertical Scroll
-(setq scroll-step 1)
-(setq scroll-margin 1)
-(setq scroll-conservatively 101)
-(setq scroll-up-aggressively 0.01)
-(setq scroll-down-aggressively 0.01)
-(setq auto-window-vscroll nil)
-(setq fast-but-imprecise-scrolling nil)
-(setq mouse-wheel-scroll-amount '(1 ((shift) . 1)))
-(setq mouse-wheel-progressive-speed nil)
-;; Horizontal Scroll
-(setq hscroll-step 1)
-(setq hscroll-margin 1)
-
-(use-package dashboard
-  :demand
-  :diminish (dashboard-mode page-break-lines-mode)
-  :custom
-  (dashboard-set-heading-icons t)
-  (dashboard-set-navigator t)
-  :config
-  (dashboard-setup-startup-hook)
-    ;; Open Dashboard function
-  (defun open-dashboard ()
-    "Open the *dashboard* buffer and jump to the first widget."
-    (interactive)
-    (if (get-buffer dashboard-buffer-name)
-        (kill-buffer dashboard-buffer-name))
-    (dashboard-insert-startupify-lists)
-    (switch-to-buffer dashboard-buffer-name)
-    (goto-char (point-min))
-    (delete-other-windows)))
-
-;; to draw nice horizontal lines
-(use-package page-break-lines
-  :diminish
-  :init (global-page-break-lines-mode))
-
-;;;;;;;;;;;;;;;;;;;;;;;;
-;; Font Configuration ;;
-;;;;;;;;;;;;;;;;;;;;;;;;
-
-(set-face-attribute 'default nil :font "Fira Code" :height arsenic/default-font-size)
-
-;; Set the fixed pitch face
-(set-face-attribute 'fixed-pitch nil :font "Fira Code" :height 150)
-
-;; Set the variable pitch face
-(set-face-attribute 'variable-pitch nil :font "Cantarell" :height 152 :weight 'regular)
-
-(use-package doom-themes
-  :custom-face
-  (cursor ((t (:background "BlanchedAlmond"))))
-  :config
-  ;; flashing mode-line on errors
-  (doom-themes-visual-bell-config)
-  ;; Corrects (and improves) org-mode's native fontification.
-  (doom-themes-org-config)
-  (load-theme 'doom-one t)
-  (defun switch-theme ()
-    "An interactive funtion to switch themes."
-    (interactive)
-    (disable-theme (intern (car (mapcar #'symbol-name custom-enabled-themes))))
-    (call-interactively #'load-theme)))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Package Manager Config ;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(require 'package)
-
-;; Initialize package resources
-(setq package-archives
-      '(("GNU" . "http://elpa.gnu.org/packages/")
-        ("MELPA" . "http://melpa.org/packages/")
-        ("nonGNU" . "https://elpa.nongnu.org/nongnu/")
-	("MELPA Stable" . "http://stable.melpa.org/packages/")))
-
-(package-initialize)
-(unless package-archive-contents
-  (package-refresh-contents))
-
-;; Initialise use package
-(unless (package-installed-p 'use-package)
-  (package-install 'use-package))
-
-(require 'use-package)
-(setq use-package-always-ensure t)
-
-(use-package swiper :ensure t)
-
-(use-package ivy
-  :diminish
-  :bind (("C-s" . swiper)
-         :map ivy-minibuffer-map
-         ("TAB" . ivy-alt-done)
-         ("C-l" . ivy-alt-done)
-         ("C-j" . ivy-next-line)
-         ("C-k" . ivy-previous-line)
-         :map ivy-switch-buffer-map
-         ("C-k" . ivy-previous-line)
-         ("C-l" . ivy-done)
-         ("C-d" . ivy-switch-buffer-kill)
-         :map ivy-reverse-i-search-map
-         ("C-k" . ivy-previous-line)
-         ("C-d" . ivy-reverse-i-search-kill))
-  :config
-  (ivy-mode 1))
-
-;; All the icons to collect various icon fonts (Enable only in GUI emacs)
-;; all the icons required for doom-modeline to work properly
-(use-package all-the-icons :if (display-graphic-p))
-
-;; remove certain minor modes from modeline
-(use-package diminish)
-
-;; modeline of omega doom
-(use-package doom-modeline
-  :custom
-  ;; Don't compact font caches during GC. Windows Laggy Issue
-  (inhibit-compacting-font-caches t)
-  (doom-modeline-minor-modes t)
-  (doom-modeline-icon t)
-  (doom-modeline-major-mode-color-icon t)
-  (doom-modeline-height 15)
-  :config
-  (doom-modeline-mode))
-
-(column-number-mode)
-(global-display-line-numbers-mode t)
-
-;; Disable line numbers for some modes
-(dolist (mode '(org-mode-hook
-                term-mode-hook
-                shell-mode-hook
-                eshell-mode-hook))
-  (add-hook mode (lambda () (display-line-numbers-mode 0))))
-
-(use-package rainbow-delimiters
-  :hook (prog-mode . rainbow-delimiters-mode))
-
-(use-package which-key
-  :init (which-key-mode)
-  :diminish which-key-mode
-  :config
-  (setq which-key-idle-delay 1))
-
-(use-package all-the-icons-ivy-rich
-  :after counsel-projectile
-  :init (all-the-icons-ivy-rich-mode +1))
-
-(use-package ivy-rich
-  :ensure t
-  :after (counsel)
-  :config (ivy-rich-mode 1))
-
-(use-package counsel
-  :bind (("M-x" . counsel-M-x)
-         ("C-x b" . counsel-ibuffer)
-         ("C-x C-f" . counsel-find-file)
-         :map minibuffer-local-map
-         ("C-r" . 'counsel-minibuffer-history)))
-
-(use-package helpful
-  :custom
-  (counsel-describe-function-function #'helpful-callable)
-  (counsel-describe-variable-function #'helpful-variable)
-  :bind
-  ([remap describe-function] . counsel-describe-function)
-  ([remap describe-command] . helpful-command)
-  ([remap describe-variable] . counsel-describe-variable)
-  ([remap describe-key] . helpful-key))
-
-(use-package projectile
-  :diminish projectile-mode
-  :config (projectile-mode)
-  :custom ((projectile-completion-system 'ivy))
-  :bind-keymap
-  ("C-c p" . projectile-command-map)
-  :init
-  ;; NOTE: Set this to the folder where you keep your Git repos!
-  (when (file-directory-p "~/Projects/Code")
-    (setq projectile-project-search-path '("~/Projects/Code")))
-  (setq projectile-switch-project-action #'projectile-dired))
-
-(use-package counsel-projectile
-  :config (counsel-projectile-mode))
-
-;; highlights uncommitted changes on the left side of the window
-(use-package diff-hl
-  :init
-        (global-diff-hl-mode)  ;; enable it globally
-        (diff-hl-margin-mode)  ;; display changes in margin instead of gutter
-        (diff-hl-flydiff-mode) ;; show hl on the fly
-)
-
-(use-package magit
-  :custom
-  (magit-display-buffer-function #'magit-display-buffer-same-window-except-diff-v1))
-
-
-;; discord rpc for emacs
-(use-package elcord
-  :init (elcord-mode))
-
-;;;;;;;;;;;;;;;;
-;; Navigation ;;
-;;;;;;;;;;;;;;;;
-
-;; fast forward direct cursor movement (like ace jump mode)
-(use-package avy
-  :bind ("M-s" . avy-goto-char-timer))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Org Mode Configuration ;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(defun efs/org-mode-setup ()
-  (org-indent-mode)
-  (variable-pitch-mode 1)
-  (visual-line-mode 1))
-
-(defun efs/org-font-setup ()
-  ;; Replace list hyphen with dot
-  (font-lock-add-keywords 'org-mode
-                          '(("^ *\\([-]\\) "
-                             (0 (prog1 () (compose-region (match-beginning 1) (match-end 1) "•"))))))
-
-  ;; Set faces for heading levels
-  (dolist (face '((org-level-1 . 1.2)
-                  (org-level-2 . 1.1)
-                  (org-level-3 . 1.05)
-                  (org-level-4 . 1.0)
-                  (org-level-5 . 1.1)
-                  (org-level-6 . 1.1)
-                  (org-level-7 . 1.1)
-                  (org-level-8 . 1.1)))
-    (set-face-attribute (car face) nil :font "Cantarell" :weight 'regular :height (cdr face)))
-
-  ;; Ensure that anything that should be fixed-pitch in Org files appears that way
-  (set-face-attribute 'org-block nil :foreground nil :inherit 'fixed-pitch)
-  (set-face-attribute 'org-code nil   :inherit '(shadow fixed-pitch))
-  (set-face-attribute 'org-table nil   :inherit '(shadow fixed-pitch))
-  (set-face-attribute 'org-verbatim nil :inherit '(shadow fixed-pitch))
-  (set-face-attribute 'org-special-keyword nil :inherit '(font-lock-comment-face fixed-pitch))
-  (set-face-attribute 'org-meta-line nil :inherit '(font-lock-comment-face fixed-pitch))
-  (set-face-attribute 'org-checkbox nil :inherit 'fixed-pitch))
-
-(use-package org
-  :hook (org-mode . efs/org-mode-setup)
-  :config
-  (setq org-ellipsis " ▾")
-
-  (setq org-agenda-start-with-log-mode t)
-  (setq org-log-done 'time)
-  (setq org-log-into-drawer t)
-
-  ;; Save Org buffers after refiling!
-  (advice-add 'org-refile :after 'org-save-all-org-buffers))
-
-(use-package org-bullets
-  :after org
-  :hook (org-mode . org-bullets-mode)
-  :custom
-  (org-bullets-bullet-list '("◉" "○" "●" "○" "●" "○" "●")))
-
-(defun efs/org-mode-visual-fill ()
-  (setq visual-fill-column-width 100
-        visual-fill-column-center-text t)
-  (visual-fill-column-mode 1))
-
-(use-package visual-fill-column
-  :hook (org-mode . efs/org-mode-visual-fill))
-
-;; This is needed as of Org 9.2
-(require 'org-tempo)
-
-(add-to-list 'org-structure-template-alist '("sh" . "src shell"))
-(add-to-list 'org-structure-template-alist '("el" . "src emacs-lisp"))
-(add-to-list 'org-structure-template-alist '("py" . "src python"))
-(add-to-list 'org-structure-template-alist '("cpp" . "src cpp"))
-
-;; dired config
-
-(use-package dired
-  :ensure nil
-  :commands (dired dired-jump)
-  :custom ((insert-directory-program "gls" dired-use-ls-dired t)
-           (dired-listing-switches "-agho --group-directories-first"))
-  :bind (("C-x C-j" . dired-jump)))
-
-(use-package dired-single)
-
-(use-package all-the-icons-dired
-  :hook (dired-mode . all-the-icons-dired-mode)
-  :init (setq all-the-icons-dired-monochrome nil))
-
-
-(use-package multiple-cursors
-  :bind ( ("C-S-c C-S-c" . mc/edit-lines)
-          ( "C->" . mc/mark-next-like-this)
-          ("C-<" . mc/mark-previous-like-this)
-          ("C-c C-<". mc/mark-all-like-this)))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Programming specific ;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(setq apropos-sort-by-scores t)
-
-;; follow gnu coding convention by defult
-(setq c-default-style "gnu")
-
-;; clang format to properly format code
-(use-package clang-format
-  :init (setq clang-format-style "GNU")
-  :bind ("C-c f" . clang-format-buffer))
-
-;;activate whitespace-mode to view all whitespace characters
-(global-set-key (kbd "C-c w") 'whitespace-mode)
-
-;; show unncessary whitespace ( it's more of a distraction for me rn)
-;;(add-hook 'prog-mode-hook (lambda () (interactive) (setq show-trailing-whitespace 1)))
-
-;; use space to indent by default
-(setq-default indent-tabs-mode nil)
-
-;; set appearance of a tab that is represented by 8 spaces
-(setq-default tab-width 8)
-
-;; dtrt-indent: to detect and set indend offset depending on the file being edited
-(use-package dtrt-indent
-  :diminish
-  :init (dtrt-indent-global-mode))
-
-;; Highlight and replace multiple occurances of a text in the buffer
-(use-package iedit)
-
-;; font-locking for "Modern C++"
-(use-package modern-cpp-font-lock
-  :diminish t
-  :init (modern-c++-font-lock-global-mode t))
-
-;; syntax checking on the fly
-(use-package flycheck
-  :diminish
-  :init (global-flycheck-mode)
-  :config
-  (add-hook 'c++-mode-hook
-          (lambda () (setq flycheck-clang-language-standard "c++2a"))))
-
-(use-package markdown-mode
-  :mode ("README\\.md\\'" . gfm-mode)
-  :init (setq markdown-command "multimarkdown"))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Aindent and we-butler to clean up useless whitespaces in source ;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-;; clean auto-indent and backspace unindent
-(use-package clean-aindent-mode
-  :diminish
-  :hook (prog-mode . clean-aindent-mode))
-
-;; strip additional whitespaces at the end of lines
-(use-package ws-butler
-  :diminish
-  :hook (prog-mode . ws-butler-mode))
-
-;; add closing parenthesis with opening ones
-(use-package smartparens
-  :hook (prog-mode . smartparens-mode)
-  :diminish smartparens-mode
-  :bind
-  (:map smartparens-mode-map
-        ("C-M-f" . sp-forward-sexp)
-        ("C-M-b" . sp-backward-sexp)
-        ("C-M-a" . sp-backward-down-sexp)
-        ("C-M-e" . sp-up-sexp)
-        ("C-M-w" . sp-copy-sexp)
-        ("C-M-k" . sp-change-enclosing)
-        ("M-k" . sp-kill-sexp)
-        ("C-M-<backspace>" . sp-splice-sexp-killing-backward)
-        ("C-S-<backspace>" . sp-splice-sexp-killing-around)
-        ("C-]" . sp-select-next-thing-exchange))
-  :custom
-  (sp-escape-quotes-after-insert nil)
-  :config
-  ;; Stop pairing single quotes in elisp
-  (sp-local-pair 'emacs-lisp-mode "'" nil :actions nil)
-  (sp-local-pair 'org-mode "[" nil :actions nil)
-;; on RET press, the curly braces automatically add another newline
-  (sp-with-modes '(c-mode c++-mode)
-    (sp-local-pair "{" nil :post-handlers '(("||\n[i]" "RET")))
-    (sp-local-pair "/*" "*/" :post-handlers '((" | " "SPC")
-                                              ("* ||\n[i]" "RET")))))
-
-;; Show matching parenthesis
-(show-paren-mode 1)
-
-;; ggtags (gnu global tags)
-(use-package ggtags
-  :init
-  (add-hook 'c-mode-common-hook
-            (lambda ()
-              (when (derived-mode-p 'c-mode 'c++-mode 'java-mode 'asm-mode)
-                (ggtags-mode 1))))
-  :bind (:map ggtags-mode-map
-              ("C-c g s" . ggtags-find-other-symbol)
-              ("C-c g h" . ggtags-view-tag-history)
-              ("C-c g r" . ggtags-find-reference)
-              ("C-c g f" . ggtags-find-file)
-              ("C-c g c" . ggtags-create-tags)
-              ("C-c g u" . ggtags-update-tags)
-              ("M-," . pop-tag-mark)
-              )
-  :config
-  ;;integrating ggtags with imenue
-  (setq-local imenu-create-index-function #'ggtags-build-imenu-index))
-
-;;;;;;;;;;;;;;;;;;;;;;;;
-;; Code auto complete ;;
-;;;;;;;;;;;;;;;;;;;;;;;;
-
-;; auto complete
-(require 'cc-mode)
-
-;; code snippets ( for more autocomplete )
-(use-package yasnippet
-  :diminish yas-minor-mode
-  :init
-  (use-package yasnippet-snippets :after yasnippet)
-  :hook ((prog-mode LaTeX-mode org-mode markdown-mode) . yas-minor-mode)
-  :bind
-  (:map yas-minor-mode-map ("C-c C-n" . yas-expand-from-trigger-key))
-  (:map yas-keymap
-        (("TAB" . smarter-yas-expand-next-field)
-         ([(tab)] . smarter-yas-expand-next-field)))
-  :config
-  (yas-reload-all)
-  (defun smarter-yas-expand-next-field ()
-    "Try to `yas-expand' then `yas-next-field' at current cursor position."
-    (interactive)
-    (let ((old-point (point))
-          (old-tick (buffer-chars-modified-tick)))
-      (yas-expand)
-      (when (and (eq old-point (point))
-                 (eq old-tick (buffer-chars-modified-tick)))
-        (ignore-errors (yas-next-field))))))
-
-(use-package company
-  :diminish company-mode
-  :hook ((prog-mode LaTeX-mode latex-mode ess-r-mode) . company-mode)
-  :bind
-  (:map company-active-map
-        ([tab] . smarter-tab-to-complete)
-        ("TAB" . smarter-tab-to-complete))
-  :custom
-  (company-minimum-prefix-length 1)
-  (company-tooltip-align-annotations t)
-  (company-require-match 'never)
-  ;; Don't use company in the following modes
-  (company-global-modes '(not shell-mode eaf-mode))
-  ;; Trigger completion immediately.
-  (company-idle-delay 0.1)
-  ;; Number the candidates (use M-1, M-2 etc to select completions).
-  (company-show-numbers t)
-  :config
-  ;;(unless clangd-p (delete 'company-clang company-backends))
-  (global-company-mode 1)
-  (defun smarter-tab-to-complete ()
-    "Try to `org-cycle', `yas-expand', and `yas-next-field' at current cursor position.
-
-If all failed, try to complete the common part with `company-complete-common'"
-    (interactive)
-    (when yas-minor-mode
-      (let ((old-point (point))
-            (old-tick (buffer-chars-modified-tick))
-            (func-list
-             (if (equal major-mode 'org-mode) '(org-cycle yas-expand yas-next-field)
-               '(yas-expand yas-next-field))))
-        (catch 'func-suceed
-          (dolist (func func-list)
-            (ignore-errors (call-interactively func))
-            (unless (and (eq old-point (point))
-                         (eq old-tick (buffer-chars-modified-tick)))
-              (throw 'func-suceed t)))
-          (company-complete-common))))))
-
-;; company-c-headers ( auto complete c header names )
-(require 'company-c-headers)
-(add-to-list 'company-backends 'company-c-headers)
-;; let company c headers also complete c++ headers
-(add-to-list 'company-c-headers-path-system "/usr/local/Cellar/gcc/11.2.0/include/c++/11.2.0")
-
-;; tab to indent and autocomplete
-(setq tab-always-indent 'complete)
-
-(use-package header2
-  :load-path (lambda () (expand-file-name "non-melpa-elisp/header2" user-emacs-directory))
-  :custom
-  (header-copyright-notice (concat "Copyright (C) 2019 " (user-full-name) "\n"))
-  :hook (emacs-lisp-mode . auto-make-header)
-  :config
-  (add-to-list 'write-file-functions 'auto-update-file-header)
-  (autoload 'auto-make-header "header2")
-  (autoload 'auto-update-file-header "header2"))
+(add-to-load-path (expand-file-name "elisp" user-emacs-directory))
+
+;; global configuration
+(require 'init-global-config)
+
+;;;;;;;;;;;;;;
+;; Packages ;;
+;;;;;;;;;;;;;;
+
+;; package manager
+(require 'init-package)
+
+(require 'init-search)
+
+(require 'init-avy)
+
+(require 'init-which-key)
+
+(require 'init-ace-window)
+
+(require 'init-dired)
+
+(require 'init-helpful)
+
+;;;;;;;;;;;;;;;
+;; UI config ::
+;;;;;;;;;;;;;;;
+
+(require 'init-ui-config)
+
+(require 'init-theme)
+
+(require 'init-font)
+
+(require 'init-dashboard)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;
+;; General Programming ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(require 'init-git)
+
+(require 'init-projectile)
+
+(require 'init-yasnippets)
+
+(require 'init-syntax)
+
+(require 'init-parens)
+
+(require 'init-indent)
+
+(require 'init-edit)
+
+(require 'init-header)
+
+(require 'init-company)
+
+;;;;;;;;;;;;;;;;;
+;; Programming ;;
+;;;;;;;;;;;;;;;;;
+
+(require 'init-cc)
+
+(require 'init-markdown)
+
+;;;;;;;;;
+;; ORG ;;
+;;;;;;;;;
+
+(require 'init-org)
+
+;;;;;;;;;;
+;; Misc ;;
+;;;;;;;;;;
+
+(require 'init-elcord)
+
+
+(provide 'init)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init.el ends here

--- a/init.el
+++ b/init.el
@@ -1,3 +1,18 @@
+(defun update-to-load-path (folder)
+  "Update FOLDER and its subdirectories to `load-path'."
+  (let ((base folder))
+    (unless (member base load-path)
+      (add-to-list 'load-path base))
+    (dolist (f (directory-files base))
+      (let ((name (concat base "/" f)))
+        (when (and (file-directory-p name)
+                   (not (equal f ".."))
+                   (not (equal f ".")))
+          (unless (member base load-path)
+            (add-to-list 'load-path name)))))))
+
+(update-to-load-path (expand-file-name "elisp" user-emacs-directory))
+
 ;; Move customization variables to a separate file and load it
 (setq custom-file (locate-user-emacs-file "custom-vars.el"))
 (load custom-file 'noerror 'nomessage)
@@ -532,3 +547,13 @@ If all failed, try to complete the common part with `company-complete-common'"
 
 ;; tab to indent and autocomplete
 (setq tab-always-indent 'complete)
+
+(use-package header2
+  :load-path (lambda () (expand-file-name "non-melpa-elisp/header2" user-emacs-directory))
+  :custom
+  (header-copyright-notice (concat "Copyright (C) 2019 " (user-full-name) "\n"))
+  :hook (emacs-lisp-mode . auto-make-header)
+  :config
+  (add-to-list 'write-file-functions 'auto-update-file-header)
+  (autoload 'auto-make-header "header2")
+  (autoload 'auto-update-file-header "header2"))


### PR DESCRIPTION
distribute init file across multiple files

the init files are not moved to `elisp/` directory, and `init.el` simply loads the path and require those init files

close #6 