### PR TITLE
global_config: toggle full screen of on startup

### DIFF
--- a/elisp/init-global-config.el
+++ b/elisp/init-global-config.el
@@ -45,7 +45,7 @@
 ;;; Code:
 
 ;; full screen by default
-(toggle-frame-fullscreen)
+;; (toggle-frame-fullscreen)
 
 ;; Replace active region by typing text
 (delete-selection-mode 1)


### PR DESCRIPTION
toggling full screen mode on startup was causing some weird performance issues on my system and was drastically increasing the startup time. I am planning to keep this switched off till the time I don't find a better method to do this.