### PR TITLE
new-package: golden ratio mode

### DIFF
--- a/elisp/init-golden-ratio.el
+++ b/elisp/init-golden-ratio.el
@@ -1,0 +1,53 @@
+;;; init-golden-ratio.el --- -*- lexical-binding -*-
+;;
+;; Filename: init-golden-ratio.el
+;; Description: initialise golden ratio mode
+;; Author: Ankur Saini
+;; Maintainer: Ankur Saini
+;; Copyright (C) 2019 Ankur Saini
+;; Created: Sun Feb 26 17:31:18 2023 (+0530)
+;; Version: 1.0
+;; Package-Requires: ()
+;; Last-Updated:
+;;           By:
+;;     Update #: 1
+;; URL: https://github.com/Arsenic-ATG/Emacs-config
+;; Keywords: golden-ratio resize
+;; Compatibility: emacs-version >= 27
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This file
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change Log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+(use-package golden-ratio
+  :config (golden-ratio-mode))
+
+(provide 'init-golden-ratio)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; init-golden-ratio.el ends here

--- a/init.el
+++ b/init.el
@@ -8,7 +8,7 @@
 ;; Version: 1.0
 ;; Last-Updated:
 ;;           By:
-;;     Update #: 83
+;;     Update #: 84
 ;; URL: https://github.com/Arsenic-ATG/Emacs-config
 ;; Keywords: init .emacs.d
 ;; Compatibility: emacs-version >= 26.1
@@ -79,6 +79,8 @@
 (require 'init-which-key)
 
 (require 'init-ace-window)
+
+(require 'init-golden-ratio)
 
 (require 'init-dired)
 


### PR DESCRIPTION
- automatically increase the size of current buffer when in split mode.
- fix #73 on Github