### PR TITLE
Fix: minor bugs found during linux installation

### DIFF
--- a/elisp/init-cc.el
+++ b/elisp/init-cc.el
@@ -9,7 +9,7 @@
 ;; Package-Requires: ()
 ;; Last-Updated:
 ;;           By:
-;;     Update #: 13
+;;     Update #: 14
 ;; URL: https://github.com/Arsenic-ATG/Emacs-config
 ;; Keywords: c c++ cc .emacs.d
 ;; Compatibility: emacs-version >= 26.1
@@ -45,7 +45,7 @@
 ;;
 ;;; Code:
 
-;; follow gnu coding convention by defult
+;; follow gnu coding formatting convention by defult
 (setq c-default-style "gnu")
 
 ;; Provides syntax highlighting and indentation for CMakeLists.txt and
@@ -54,18 +54,17 @@
 
 ;; font-locking for "Modern C++"
 (use-package modern-cpp-font-lock
-  :diminish t
-  :init (modern-c++-font-lock-global-mode t))
+  :diminish t)
 
 ;; company-c-headers ( auto complete c header names )
-(require 'company-c-headers)
+(use-package company-c-headers)
 (add-to-list 'company-backends 'company-c-headers)
 ;; let company c headers also complete c++ headers
 ;;
 ;; TODO: fetch this information form a variables insetaed of
 ;; hardcoding it here ( as the path might not be same for all the
 ;; devices using the configuration)
-(add-to-list 'company-c-headers-path-system "/usr/local/Cellar/gcc/11.2.0/include/c++/11.2.0")
+;; (add-to-list 'company-c-headers-path-system "/usr/local/Cellar/gcc/11.2.0/include/c++/11.2.0")
 
 (provide 'init-cc)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/elisp/init-font.el
+++ b/elisp/init-font.el
@@ -49,10 +49,10 @@
 (set-face-attribute 'default nil :font "Fira Code" :height arsenic/default-font-size)
 
 ;; Set the fixed pitch face
-(set-face-attribute 'fixed-pitch nil :font "Fira Code" :height 150)
+(set-face-attribute 'fixed-pitch nil :font "Fira Code" :height arsenic/default-font-size)
 
 ;; Set the variable pitch face
-(set-face-attribute 'variable-pitch nil :font "Cantarell" :height 152 :weight 'regular)
+(set-face-attribute 'variable-pitch nil :font "Cantarell" :height arsenic/default-font-size :weight 'regular)
 
 (provide 'init-font)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/elisp/init-theme.el
+++ b/elisp/init-theme.el
@@ -9,7 +9,7 @@
 ;; Package-Requires: ()
 ;; Last-Updated:
 ;;           By:
-;;     Update #: 18
+;;     Update #: 19
 ;; URL:  https://github.com/Arsenic-ATG/Emacs-config
 ;; Keywords: theme .emacs.d
 ;; Compatibility: emacs-version >= 26.1
@@ -70,6 +70,7 @@
 
 ;; All the icons to collect various icon fonts (Enable only in GUI emacs)
 ;; all the icons required for doom-modeline to work properly
+;; use "nerd-icons-install-fonts" if icons are not rendering properly
 (use-package all-the-icons :if (display-graphic-p))
 
 ;; modeline of omega doom

--- a/elisp/init-ui-config.el
+++ b/elisp/init-ui-config.el
@@ -51,6 +51,10 @@
 (tool-bar-mode -1)          ; Disable the toolbar
 (tooltip-mode -1)           ; Disable tooltips
 (set-fringe-mode 10)        ; Give some breathing room
+(if (not (eq system-type 'darwin))
+    (menu-bar-mode -1)      ; Disable menue bar (in all OS apart from macOS)
+; Disabling menu bar on macOS causes some weird UI glitch in full screen mode.
+)
 
 ;; Use "y/n" instead of "yes/no" prompt
 (fset 'yes-or-no-p 'y-or-n-p)


### PR DESCRIPTION
- init-cc.el
  - remove double initialsation of modern-c++-font-lock (fix #134 on Gtihub)
  - wrap company-c-headers in use-package decl (fix #130 on Github)
  - comment out comany c header path system ( TODO: extract the patch dynamically for different systems )
- init-font.el
  - Change font height to variable (fix #135 on GitHub)
- init-ui-config.el
  - Disable menu bar (fix #136 on Github)

ref #131 